### PR TITLE
fix: connect id with labels for forms accessibility #18

### DIFF
--- a/components/kit/components/form/inputtext/InputText.tsx
+++ b/components/kit/components/form/inputtext/InputText.tsx
@@ -12,6 +12,7 @@ interface Props {
   disabled?: boolean;
   square?: boolean;
   withForceIndications?: boolean;
+  id?: string;
 }
 
 const InputText = (props: Props) => {
@@ -22,10 +23,10 @@ const InputText = (props: Props) => {
       }`}
     >
       {props.label && (
-        <label htmlFor={props.name} className="text-gray-700">
+        <label htmlFor={props.id} className="text-gray-700">
           {props.label}{" "}
           {props.required && (
-            <span className="required-dot text-red-500">*</span>
+            <span className="text-red-500 required-dot">*</span>
           )}
         </label>
       )}
@@ -39,6 +40,7 @@ const InputText = (props: Props) => {
         </span>
       )}
       <input
+      id={props.id}
         disabled={props.disabled}
         className={`${props.error ? "ring-red-500 ring-2" : ""}${
           props.helper || props.icon
@@ -55,13 +57,13 @@ const InputText = (props: Props) => {
       />
       {props.withForceIndications && (
         <>
-          <div className="w-full grid grid-cols-12 gap-4 h-1 mt-3">
-            <div className="col-span-3 h-full rounded bg-green-500"></div>
-            <div className="col-span-3 h-full rounded bg-green-500"></div>
-            <div className="col-span-3 h-full rounded bg-green-500"></div>
-            <div className="col-span-3 h-full rounded bg-gray-200 dark:bg-dark-1"></div>
+          <div className="grid w-full h-1 grid-cols-12 gap-4 mt-3">
+            <div className="h-full col-span-3 bg-green-500 rounded"></div>
+            <div className="h-full col-span-3 bg-green-500 rounded"></div>
+            <div className="h-full col-span-3 bg-green-500 rounded"></div>
+            <div className="h-full col-span-3 bg-gray-200 rounded dark:bg-dark-1"></div>
           </div>
-          <div className="text-green-500 mt-2">Valid password</div>
+          <div className="mt-2 text-green-500">Valid password</div>
         </>
       )}
       {props.error && (
@@ -71,13 +73,13 @@ const InputText = (props: Props) => {
             width="15"
             height="15"
             fill="currentColor"
-            className="absolute right-2 text-red-500 bottom-3"
+            className="absolute text-red-500 right-2 bottom-3"
             viewBox="0 0 1792 1792"
           >
             <path d="M1024 1375v-190q0-14-9.5-23.5t-22.5-9.5h-192q-13 0-22.5 9.5t-9.5 23.5v190q0 14 9.5 23.5t22.5 9.5h192q13 0 22.5-9.5t9.5-23.5zm-2-374l18-459q0-12-10-19-13-11-24-11h-220q-11 0-24 11-10 7-10 21l17 457q0 10 10 16.5t24 6.5h185q14 0 23.5-6.5t10.5-16.5zm-14-934l768 1408q35 63-2 126-17 29-46.5 46t-63.5 17h-1536q-34 0-63.5-17t-46.5-46q-37-63-2-126l768-1408q17-31 47-49t65-18 65 18 47 49z" />
           </svg>
 
-          <p className="absolute -bottom-6 text-red-500 text-sm">
+          <p className="absolute text-sm text-red-500 -bottom-6">
             {props.error}
           </p>
         </>

--- a/components/kit/components/form/layout/ContactForm.tsx
+++ b/components/kit/components/form/layout/ContactForm.tsx
@@ -6,18 +6,18 @@ import Button from "../../elements/buttons/Button";
 const ContactForm = () => {
   return (
     <form className="flex w-full max-w-sm space-x-3">
-      <div className="max-w-2xl bg-white dark:bg-gray-800 py-10 px-5 m-auto w-full mt-10 shadow rounded-lg">
-        <div className="text-3xl mb-6 font-light text-gray-800 dark:text-white text-center">
+      <div className="w-full max-w-2xl px-5 py-10 m-auto mt-10 bg-white rounded-lg shadow dark:bg-gray-800">
+        <div className="mb-6 text-3xl font-light text-center text-gray-800 dark:text-white">
           Contact us !
         </div>
 
-        <div className="grid grid-cols-2 gap-4 max-w-xl m-auto">
+        <div className="grid max-w-xl grid-cols-2 gap-4 m-auto">
           <div className="col-span-2 lg:col-span-1">
-            <InputText placeholder="Name" />
+            <InputText placeholder="Name" id="contact-form-name" />
           </div>
 
           <div className="col-span-2 lg:col-span-1">
-            <InputText placeholder="email" />
+            <InputText placeholder="email" id="contact-form-email"  />
           </div>
 
           <div className="col-span-2">

--- a/components/kit/components/form/layout/CreateAccount.tsx
+++ b/components/kit/components/form/layout/CreateAccount.tsx
@@ -5,39 +5,39 @@ import Checkbox from "../toggle/Checkbox";
 
 const CreateAccount = () => {
   return (
-    <div className="flex flex-col bg-white dark:bg-gray-800 shadow px-4 sm:px-6 md:px-8 lg:px-10 py-8 rounded-lg max-w-md">
-      <div className="font-light self-center text-xl sm:text-2xl text-gray-800 dark:text-white mb-2">
+    <div className="flex flex-col max-w-md px-4 py-8 bg-white rounded-lg shadow dark:bg-gray-800 sm:px-6 md:px-8 lg:px-10">
+      <div className="self-center mb-2 text-xl font-light text-gray-800 sm:text-2xl dark:text-white">
         Create a new account
       </div>
-      <span className="flex-items-center text-gray-500 dark:text-gray-400 justify-center text-center text-sm">
+      <span className="justify-center text-sm text-center text-gray-500 flex-items-center dark:text-gray-400">
         Already have an account ?
         <a
           href="#"
           target="_blank"
-          className="text-blue-500 hover:text-blue-700 text-sm underline"
+          className="text-sm text-blue-500 underline hover:text-blue-700"
         >
           Sign in
         </a>
       </span>
 
-      <div className="mt-8 p-6">
+      <div className="p-6 mt-8">
         <form action="#">
           <div className="flex flex-col mb-2">
-            <InputText name="pseudo" type="text" placeholder="Pseudo" />
+            <InputText name="pseudo" type="text" placeholder="Pseudo" id="create-account-pseudo"  />
           </div>
           <div className="flex gap-4 mb-2">
-            <InputText name="First name" type="text" placeholder="First name" />
-            <InputText name="Last name" type="text" placeholder="Last name" />
+            <InputText name="First name" type="text" placeholder="First name" id="create-account-first-name"  />
+            <InputText name="Last name" type="text" placeholder="Last name" id="create-account-last-name"  />
           </div>
           <div className="flex flex-col mb-2">
-            <InputText type="text" placeholder="Email" />
+            <InputText type="text" placeholder="Email" id="create-account-email"  />
           </div>
 
           <div className="flex w-full my-4">
             <Button submit={true} label="Login" color="purple" />
           </div>
         </form>
-        <div className="flex justify-center items-center mt-6">
+        <div className="flex items-center justify-center mt-6">
           <Checkbox label="I have read and agree term of services " />
         </div>
       </div>

--- a/components/kit/components/form/layout/DesignLogin.tsx
+++ b/components/kit/components/form/layout/DesignLogin.tsx
@@ -4,16 +4,16 @@ import React from "react";
 
 const DesignLogin = () => {
   return (
-    <div className="w-full flex flex-wrap">
-      <div className="w-full md:w-1/2 flex flex-col">
-        <div className="flex justify-center md:justify-start pt-12 md:pl-12 md:-mb-24">
-          <a href="#" className="bg-black text-white font-bold text-xl p-4">
+    <div className="flex flex-wrap w-full">
+      <div className="flex flex-col w-full md:w-1/2">
+        <div className="flex justify-center pt-12 md:justify-start md:pl-12 md:-mb-24">
+          <a href="#" className="p-4 text-xl font-bold text-white bg-black">
             Design.
           </a>
         </div>
 
-        <div className="flex flex-col justify-center md:justify-start my-auto pt-8 md:pt-0 px-8 md:px-24 lg:px-32">
-          <p className="text-center text-3xl">Welcome.</p>
+        <div className="flex flex-col justify-center px-8 pt-8 my-auto md:justify-start md:pt-0 md:px-24 lg:px-32">
+          <p className="text-3xl text-center">Welcome.</p>
           <form className="flex flex-col pt-3 md:pt-8">
             <div className="flex flex-col pt-4">
               <InputText
@@ -30,6 +30,7 @@ const DesignLogin = () => {
                   </svg>
                 }
                 placeholder="Email"
+                id="design-login-email"
               />
             </div>
 
@@ -49,20 +50,21 @@ const DesignLogin = () => {
                   </svg>
                 }
                 placeholder="Password"
+                id="design-login-password"
               />
             </div>
 
             <button
               type="submit"
-              className="py-2 px-4 bg-black text-white w-full transition ease-in duration-200 text-center text-base font-semibold shadow-md hover:text-black hover:bg-white focus:outline-none focus:ring-2"
+              className="w-full px-4 py-2 text-base font-semibold text-center text-white transition duration-200 ease-in bg-black shadow-md hover:text-black hover:bg-white focus:outline-none focus:ring-2"
             >
               <span className="w-full">Submit</span>
             </button>
           </form>
-          <div className="text-center pt-12 pb-12">
+          <div className="pt-12 pb-12 text-center">
             <p>
               Don't have an account?{" "}
-              <a href="register.html" className="underline font-semibold">
+              <a href="register.html" className="font-semibold underline">
                 Register here.
               </a>
             </p>
@@ -72,7 +74,7 @@ const DesignLogin = () => {
 
       <div className="w-1/2 shadow-2xl">
         <img
-          className="object-cover w-full h-screen hidden md:block"
+          className="hidden object-cover w-full h-screen md:block"
           src="/images/object/9.jpg"
         />
       </div>

--- a/components/kit/components/form/layout/FormSubscribe.tsx
+++ b/components/kit/components/form/layout/FormSubscribe.tsx
@@ -4,9 +4,9 @@ import InputText from "../inputtext/InputText";
 const FormSubscribe = ({ label, placeholder }) => {
   return (
     <form className="flex w-full max-w-sm space-x-3">
-      <InputText placeholder={placeholder} />
+      <InputText placeholder={placeholder}  id={`"form-subscribe-${label}`}  />
       <button
-        className="flex-shrink-0 bg-purple-600 text-white text-base font-semibold py-2 px-4 rounded-lg shadow-md hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 focus:ring-offset-purple-200"
+        className="flex-shrink-0 px-4 py-2 text-base font-semibold text-white bg-purple-600 rounded-lg shadow-md hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 focus:ring-offset-purple-200"
         type="submit"
       >
         {label}

--- a/components/kit/components/form/layout/LoginWithBackground.tsx
+++ b/components/kit/components/form/layout/LoginWithBackground.tsx
@@ -4,26 +4,26 @@ import Button from "../../elements/buttons/Button";
 
 const LoginWithBackground = () => {
   return (
-    <div className="h-screen w-full font-sans bg-landscape bg-cover">
-      <div className="container mx-auto h-full flex flex-1 justify-center items-center">
+    <div className="w-full h-screen font-sans bg-cover bg-landscape">
+      <div className="container flex items-center justify-center flex-1 h-full mx-auto">
         <div className="w-full max-w-lg">
           <div className="leading-loose">
-            <form className="max-w-sm m-auto p-10 bg-white bg-opacity-25 rounded shadow-xl">
-              <p className="text-white mb-8 font-light text-center text-2xl">
+            <form className="max-w-sm p-10 m-auto bg-white bg-opacity-25 rounded shadow-xl">
+              <p className="mb-8 text-2xl font-light text-center text-white">
                 Login
               </p>
               <div className="mb-2">
-                <InputText placeholder="email" />
+                <InputText placeholder="email"  id="login-with-bg-email" />
               </div>
               <div className="mb-2">
-                <InputText placeholder="password" type="password" />
+                <InputText placeholder="password" id="login-with-bg-password"  />
               </div>
 
-              <div className="mt-4 items-center flex justify-between">
+              <div className="flex items-center justify-between mt-4">
                 <Button submit={true} color="indigo" label="Validate" />
               </div>
               <div className="text-center">
-                <a className="inline-block right-0 align-baseline font-light text-sm text-500 hover:text-gray-800">
+                <a className="right-0 inline-block text-sm font-light align-baseline text-500 hover:text-gray-800">
                   Create an account
                 </a>
               </div>

--- a/components/kit/components/form/layout/SearchForm.tsx
+++ b/components/kit/components/form/layout/SearchForm.tsx
@@ -4,26 +4,26 @@ import InputText from "../../../components/form/inputtext/InputText";
 
 const SearchForm = () => {
   return (
-    <div className="bg-white sm:max-w-md shadow sm:w-full sm:mx-auto rounded-lg sm:overflow-hidden">
+    <div className="bg-white rounded-lg shadow sm:max-w-md sm:w-full sm:mx-auto sm:overflow-hidden">
       <div className="px-4 py-8 sm:px-10">
-        <div className="mt-6 relative">
+        <div className="relative mt-6">
           <div className="absolute inset-0 flex items-center">
             <div className="w-full border-t border-gray-300"></div>
           </div>
           <div className="relative flex justify-center text-sm leading-5">
-            <span className="px-2 bg-white text-gray-500">Search criteria</span>
+            <span className="px-2 text-gray-500 bg-white">Search criteria</span>
           </div>
         </div>
         <div className="mt-6">
-          <div className="space-y-6 w-full">
+          <div className="w-full space-y-6">
             <div className="w-full">
-              <InputText placeholder="Your price" />
+              <InputText placeholder="Your price" id="search-form-price"  />
             </div>
             <div className="w-full">
-              <InputText placeholder="Your location" />
+              <InputText placeholder="Your location"  id="search-form-location" />
             </div>
             <div className="w-full">
-              <InputText placeholder="Your name" />
+              <InputText placeholder="Your name"  id="search-form-name"   />
             </div>
             <div>
               <span className="block w-full rounded-md shadow-sm">
@@ -33,7 +33,7 @@ const SearchForm = () => {
           </div>
         </div>
       </div>
-      <div className="px-4 py-6 bg-gray-50 border-t-2 border-gray-200 sm:px-10">
+      <div className="px-4 py-6 border-t-2 border-gray-200 bg-gray-50 sm:px-10">
         <p className="text-xs leading-5 text-gray-500">
           This data are display for information and can change
         </p>

--- a/components/kit/components/form/layout/SignIn.tsx
+++ b/components/kit/components/form/layout/SignIn.tsx
@@ -9,13 +9,13 @@ interface Props {
 
 const SignIn = (props: Props) => {
   return (
-    <div className="flex flex-col bg-white dark:bg-gray-800 shadow px-4 sm:px-6 md:px-8 lg:px-10 py-8 rounded-lg w-full max-w-md">
-      <div className="font-light self-center text-xl sm:text-2xl text-gray-600 dark:text-white mb-6">
+    <div className="flex flex-col w-full max-w-md px-4 py-8 bg-white rounded-lg shadow dark:bg-gray-800 sm:px-6 md:px-8 lg:px-10">
+      <div className="self-center mb-6 text-xl font-light text-gray-600 sm:text-2xl dark:text-white">
         Login To Your Account
       </div>
 
       {(props.withFacebook || props.withGoogle) && (
-        <div className="flex item-center gap-4">
+        <div className="flex gap-4 item-center">
           {props.withFacebook && (
             <Button
               label="Facebook"
@@ -72,6 +72,7 @@ const SignIn = (props: Props) => {
                 </svg>
               }
               placeholder="Your email"
+              id="sign-in-email"
             />
           </div>
           <div className="flex flex-col mb-6">
@@ -89,6 +90,7 @@ const SignIn = (props: Props) => {
               }
               type="password"
               placeholder="Your password"
+              id="sign-in-email"
             />
           </div>
 
@@ -96,7 +98,7 @@ const SignIn = (props: Props) => {
             <div className="flex ml-auto">
               <a
                 href="#"
-                className="inline-flex text-xs font-thin sm:text-sm text-gray-500 dark:text-gray-100 hover:text-gray-700 dark:hover:text-white"
+                className="inline-flex text-xs font-thin text-gray-500 sm:text-sm dark:text-gray-100 hover:text-gray-700 dark:hover:text-white"
               >
                 Forgot Your Password?
               </a>
@@ -108,11 +110,11 @@ const SignIn = (props: Props) => {
           </div>
         </form>
       </div>
-      <div className="flex justify-center items-center mt-6">
+      <div className="flex items-center justify-center mt-6">
         <a
           href="#"
           target="_blank"
-          className="inline-flex items-center font-thin text-gray-500 hover:text-gray-700 dark:text-gray-100 dark:hover:text-white text-xs text-center"
+          className="inline-flex items-center text-xs font-thin text-center text-gray-500 hover:text-gray-700 dark:text-gray-100 dark:hover:text-white"
         >
           <span className="ml-2">You don't have an account?</span>
         </a>

--- a/components/kit/components/form/layout/UserInfoForm.tsx
+++ b/components/kit/components/form/layout/UserInfoForm.tsx
@@ -5,9 +5,9 @@ import Button from "../../elements/buttons/Button";
 
 const UserInfoForm = () => {
   return (
-    <section className="bg-gray-100 bg-opacity-50 h-screen">
-      <form className="mx-auto container max-w-2xl md:w-3/4 shadow-md">
-        <div className="bg-gray-100 p-4 border-t-2 bg-opacity-5 border-indigo-400 rounded-lg">
+    <section className="h-screen bg-gray-100 bg-opacity-50">
+      <form className="container max-w-2xl mx-auto shadow-md md:w-3/4">
+        <div className="p-4 bg-gray-100 border-t-2 border-indigo-400 rounded-lg bg-opacity-5">
           <div className="max-w-sm mx-auto md:w-full md:mx-0">
             <div className="inline-flex items-center space-x-4">
               <Avatar />
@@ -15,42 +15,42 @@ const UserInfoForm = () => {
             </div>
           </div>
         </div>
-        <div className="bg-white space-y-6">
-          <div className="md:inline-flex space-y-4 md:space-y-0 w-full p-4 text-gray-500 items-center">
-            <h2 className="md:w-1/3 max-w-sm mx-auto">Account</h2>
-            <div className="md:w-2/3 max-w-sm mx-auto">
-              <InputText placeholder="Email" />
+        <div className="space-y-6 bg-white">
+          <div className="items-center w-full p-4 space-y-4 text-gray-500 md:inline-flex md:space-y-0">
+            <h2 className="max-w-sm mx-auto md:w-1/3">Account</h2>
+            <div className="max-w-sm mx-auto md:w-2/3">
+              <InputText placeholder="Email"  id="user-info-email"  />
             </div>
           </div>
 
           <hr />
-          <div className="md:inline-flex space-y-4 md:space-y-0  w-full p-4 text-gray-500 items-center">
-            <h2 className="md:w-1/3 mx-auto max-w-sm">Personal info</h2>
-            <div className="md:w-2/3 mx-auto max-w-sm space-y-5">
+          <div className="items-center w-full p-4 space-y-4 text-gray-500 md:inline-flex md:space-y-0">
+            <h2 className="max-w-sm mx-auto md:w-1/3">Personal info</h2>
+            <div className="max-w-sm mx-auto space-y-5 md:w-2/3">
               <div>
-                <InputText placeholder="Name" />
+                <InputText placeholder="Name" id="user-info-name" />
               </div>
               <div>
-                <InputText placeholder="Phone number" />
+                <InputText placeholder="Phone number" id="user-info-phone" />
               </div>
             </div>
           </div>
 
           <hr />
-          <div className="md:inline-flex w-full space-y-4 md:space-y-0 p-8 text-gray-500 items-center">
-            <h2 className="md:w-4/12 max-w-sm mx-auto">Change password</h2>
+          <div className="items-center w-full p-8 space-y-4 text-gray-500 md:inline-flex md:space-y-0">
+            <h2 className="max-w-sm mx-auto md:w-4/12">Change password</h2>
 
-            <div className="md:w-5/12 w-full md:pl-9 max-w-sm mx-auto space-y-5 md:inline-flex pl-2">
-              <InputText placeholder="Password" />
+            <div className="w-full max-w-sm pl-2 mx-auto space-y-5 md:w-5/12 md:pl-9 md:inline-flex">
+              <InputText placeholder="Password" id="user-info-password" />
             </div>
 
-            <div className="md:w-3/12 text-center md:pl-6">
+            <div className="text-center md:w-3/12 md:pl-6">
               <Button color="pink" label="Change" />
             </div>
           </div>
 
           <hr />
-          <div className="w-full md:w-1/3 px-4 pb-4 ml-auto text-gray-500">
+          <div className="w-full px-4 pb-4 ml-auto text-gray-500 md:w-1/3">
             <Button submit={true} color="blue" label="Save" />
           </div>
         </div>

--- a/pages/components/inputtext/index.tsx
+++ b/pages/components/inputtext/index.tsx
@@ -16,18 +16,18 @@ const InputTextPage: FC = () => {
 
       <ComponentLayout
         title="Simple"
-        element={<InputText square={true} placeholder="Your email" />}
+        element={<InputText square={true} placeholder="Your email" id="simple-email"  />}
         component={InputText}
       />
       <ComponentLayout
         title="Rounded"
-        element={<InputText placeholder="Your email" />}
+        element={<InputText placeholder="Your email" id="rounded-email"  />}
         component={InputText}
       />
       <ComponentLayout
         title="with label"
         element={
-          <InputText label="Email" name="email" placeholder="Your name" />
+          <InputText label="Email" name="email" placeholder="Your name" id="name-with-label"  />
         }
         component={InputText}
       />
@@ -39,6 +39,7 @@ const InputTextPage: FC = () => {
             required
             name="email"
             placeholder="Your email"
+            id="required-email"
           />
         }
         component={InputText}
@@ -52,6 +53,7 @@ const InputTextPage: FC = () => {
             required
             name="email"
             placeholder="Your email"
+            id="on-error-email"
           />
         }
         component={InputText}
@@ -65,6 +67,7 @@ const InputTextPage: FC = () => {
             required
             name="passwor"
             placeholder="Password"
+            id="with-indications"
           />
         }
         component={InputText}
@@ -77,6 +80,7 @@ const InputTextPage: FC = () => {
             disabled={true}
             name="email"
             placeholder="Your email"
+            id="disabled-email"
           />
         }
         component={InputText}
@@ -98,6 +102,7 @@ const InputTextPage: FC = () => {
             }
             name="email"
             placeholder="Your email"
+            id="email-with-icon"
           />
         }
         component={InputText}
@@ -105,7 +110,7 @@ const InputTextPage: FC = () => {
       <ComponentLayout
         title="with helper"
         element={
-          <InputText helper="http://" name="url" placeholder="www.google.com" />
+          <InputText helper="http://" name="url" placeholder="www.google.com" id="with-email"  />
         }
         component={InputText}
       />


### PR DESCRIPTION
This PR aims to resolve #18 

* An optional `id` attribute was added to `<InputText>` component 
PropTypes 
* The value of the `htmlFor` attribute of `input` labels was made to evaluate to the `props.id` value
* `id` values were added to already existing components


**Notes**

* I noticed that the name of the package does not follow the convention for naming packages by `npm`. You may want to change it to `fast-ui` or `tail-kit`
