### PR TITLE
asPath instead of pathname

### DIFF
--- a/components/site/Meta.tsx
+++ b/components/site/Meta.tsx
@@ -6,7 +6,7 @@ const Meta = ({ pageTitle, description }) => {
   const router = useRouter();
 
   const url = 'https://www.tailwind-kit.com';
-  const path = router.pathname;
+  const path = router.asPath;
 
   return (
     <Head>


### PR DESCRIPTION
Hey,

I noticed a mistake. asPath contains the correct path, while pathname contains the page name. But the page name could be something else too (if it's a dynamic page).

- pages/test/[slug].js => foo.com/test/bar=> pathname: ``/test/[slug]`` asPath: `/test/bar`  .