### PR TITLE
comma position fixed in finance card price, slight update in toggle button

### DIFF
--- a/components/kit/components/elements/data/InfoNumberCard3.tsx
+++ b/components/kit/components/elements/data/InfoNumberCard3.tsx
@@ -19,7 +19,7 @@ const InfoNumberCard3: FC = () => {
             </div>
             <div className="flex flex-col justify-start">
                 <p className="text-gray-700 dark:text-gray-100 text-4xl text-left font-bold my-4">
-                    3,4500<span className="text-sm">$</span>
+                    34,500<span className="text-sm">$</span>
                 </p>
                 <div className="flex items-center text-green-500 text-sm">
                     <svg

--- a/components/kit/components/form/toggle/MultipleToggle.tsx
+++ b/components/kit/components/form/toggle/MultipleToggle.tsx
@@ -58,7 +58,7 @@ const MultipleToggle = (props: Props) => {
                                 name="toggle"
                                 id={color.label}
                                 onChange={(e) => props.onChange(e.target.checked)}
-                                className={`${color.color} checked:right-0 absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer`}
+                                className={`${color.color} focus:outline-none checked:right-0 absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer`}
                             />
                             <label
                                 htmlFor={color.label}


### PR DESCRIPTION
Just fixed a comma position at the finance card price. Nothing fancy that would change app behavior. 