### PR TITLE
Fix grammatical error in select boxes' default value

### DIFF
--- a/components/kit/components/form/select/Select.tsx
+++ b/components/kit/components/form/select/Select.tsx
@@ -6,7 +6,7 @@ const Select = () => {
             className="block w-52 text-gray-700 py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
             name="animals"
         >
-            <option value="">Select an options</option>
+            <option value="">Select an option</option>
             <option value="dog">Dog</option>
             <option value="cat">Cat</option>
             <option value="hamster">Hamster</option>

--- a/components/kit/components/form/select/SelectWithLabel.tsx
+++ b/components/kit/components/form/select/SelectWithLabel.tsx
@@ -9,7 +9,7 @@ const SelectWithLabel = () => {
                 className="block w-52 py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
                 name="animals"
             >
-                <option value="">Select an options</option>
+                <option value="">Select an option</option>
                 <option value="dog">Dog</option>
                 <option value="cat">Cat</option>
                 <option value="hamster">Hamster</option>


### PR DESCRIPTION
## Fixes a grammatical error in the default value of select boxes

Select an options -> Select an **option**

Can be seen on: https://www.tailwind-kit.com/components/inputselect

### Before:
![before](https://user-images.githubusercontent.com/14860945/124936977-d5932200-dfbb-11eb-8c4b-047130cd9d0f.png)

### After:
![after](https://user-images.githubusercontent.com/14860945/124937005-dc219980-dfbb-11eb-8183-b73be8c49b6c.png)


- [x] I have read and followed the [contribution guidelines](.github/CONTRIBUTING.md)

For more information see the [contribution guidelines](.github/CONTRIBUTING.md)
