### PR TITLE
Fix spelling error

### DIFF
--- a/components/kit/components/elements/data/GoogleTask.tsx
+++ b/components/kit/components/elements/data/GoogleTask.tsx
@@ -68,7 +68,7 @@ const GoogleTask: FC = () => {
                     PROGRESS
                 </span>
                 <span className="px-2 py-1 flex items-center font-semibold text-xs rounded-md text-red-400 border border-red-400  bg-white">
-                    HIGHT PRIORITY
+                    HIGH PRIORITY
                 </span>
             </div>
 


### PR DESCRIPTION
## Fixes a spelling error in the Google Task Card

**HIGHT** PRIORITY -> **HIGH** PRIORITY

### Before:
![Before](https://user-images.githubusercontent.com/14860945/127613793-8d49b071-1328-47ac-b083-895450f6a499.PNG)


### After:
![After](https://user-images.githubusercontent.com/14860945/127613800-5b06c70b-92b9-4e81-a07e-293bd00af730.PNG)


- [x] I have read and followed the [contribution guidelines](.github/CONTRIBUTING.md)

For more information see the [contribution guidelines](.github/CONTRIBUTING.md)
